### PR TITLE
verbose output empty tile warning

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -177,7 +177,7 @@ module.exports = function(options, repo, params, id, publicUrl, dataResolver) {
                 format = parts[5].split('.')[1];
             source.getTile(z, x, y, function(err, data, headers) {
               if (err) {
-                //console.log('MBTiles error, serving empty', err);
+                if (options.verbose) console.log('MBTiles error, serving empty', err);
                 createEmptyResponse(sourceInfo.format, sourceInfo.color, callback);
                 return;
               }


### PR DESCRIPTION
Empty tile warning details; definitely what you would expect if there's not a catastrophic error, but you're getting blank tiles.

such as: ```
MBTiles error, serving empty { Error: SQLITE_CORRUPT: database disk image is malformed
lily_tile_server |     at Error (native) errno: 11, code: 'SQLITE_CORRUPT' }

```
https://github.com/klokantech/tileserver-gl/issues/323